### PR TITLE
fix(tracking): conversiones directo a API real, sin N8N — Plataforma (#39)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,18 +49,46 @@ export default async function RootLayout({
     <Providers country={country} countries={countries}>
       <html lang="es" dir="ltr">
         <GoogleTagManager gtmId="GTM-5W7F9MSP" />
-        <head />
+        <head>
+          {/* Google Ads — Plataforma (AW-17962976949) */}
+          <Script
+            src="https://www.googletagmanager.com/gtag/js?id=AW-17962976949"
+            strategy="afterInteractive"
+          />
+          <Script id="google-ads-plataforma" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'AW-17962976949');
+              gtag('config', 'G-BENT3HE0M6');
+            `}
+          </Script>
+          {/* Meta Pixel — Plataforma (1722871789075263) */}
+          <Script id="meta-pixel-plataforma" strategy="afterInteractive">
+            {`
+              !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+              n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}
+              (window,document,'script','https://connect.facebook.net/en_US/fbevents.js');
+              fbq('init', '1722871789075263');
+              fbq('track', 'PageView');
+            `}
+          </Script>
+          <noscript>
+            <img height="1" width="1" style={{ display: 'none' }}
+              src="https://www.facebook.com/tr?id=1722871789075263&ev=PageView&noscript=1" alt="" />
+          </noscript>
+        </head>
         <body
           className={`${canaroFont.variable} ${adobeCleanFont.variable} ${caslonFont.variable} antialiased font-adobe`}
         >
-          {/* Deshabilitar debugger statements */}
           <Script id="disable-debugger" strategy="beforeInteractive">
             {`
               (function() {
                   const originalDebugger = window.debugger;
-                  window.debugger = function() {
-                      return;
-                  };
+                  window.debugger = function() { return; };
               })();
             `}
           </Script>
@@ -68,7 +96,6 @@ export default async function RootLayout({
           <ModalRenderer />
           <Toast />
           <Whatsapp message="Hola, vi su web y quiero saber más sobre Sena y cómo funciona." animated />
-          {/* Nino Chat — Landing widget */}
           <NinoChatInit />
         </body>
       </html>

--- a/src/ui/contactanos/sections/ContactForm.tsx
+++ b/src/ui/contactanos/sections/ContactForm.tsx
@@ -32,7 +32,7 @@ type FormData = {
 
 export const ContactForm = () => {
   const { postTestn8nMutate, isLoadingPostTestn8n } = usePostTestn8n()
-  const { postContactFormMutate } = usePostContactForm()
+  const { postContactFormMutate, isLoadingPostContactForm } = usePostContactForm()
   const { data: countries = [] } = useCountries()
   const { ipCurrency } = useCurrencyStore()
   const router = useRouter()
@@ -126,9 +126,7 @@ export const ContactForm = () => {
       utmContent: utmContent || undefined,
     }
 
-    // Llamar ambas APIs
-    postContactFormMutate(contactPayload)
-    postTestn8nMutate(payload, {
+    postContactFormMutate(contactPayload, {
       onSuccess: () => {
         if (window.gtag) {
           window.gtag('event', 'conversion', { send_to: 'AW-17962976949/JNP9CMq42ZgcELWNtfVC' })
@@ -147,6 +145,7 @@ export const ContactForm = () => {
         })
       },
     })
+    postTestn8nMutate(payload)
   }
 
   return (
@@ -350,11 +349,11 @@ export const ContactForm = () => {
 
             <Button
               type="submit"
-              text={isLoadingPostTestn8n ? 'Enviando...' : 'Enviar'}
+              text={isLoadingPostContactForm ? 'Enviando...' : 'Enviar'}
               variant="primaryFilled"
               size="md"
               className="w-[200px]"
-              disabled={isLoadingPostTestn8n}
+              disabled={isLoadingPostContactForm}
             />
           </form>
         </div>

--- a/src/ui/contactanos/sections/ContactForm.tsx
+++ b/src/ui/contactanos/sections/ContactForm.tsx
@@ -13,6 +13,13 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 
+declare global {
+  interface Window {
+    fbq?: (...args: unknown[]) => void
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
 type FormData = {
   nombre: string
   apellido: string
@@ -109,7 +116,7 @@ export const ContactForm = () => {
       telefono: telefonoConPrefijo,
       formOrigin: 'Formulario de Registro',
       countryName: pais,
-      productType: 'main',
+      productType: 'plataforma',
       nombreEmpresa: data.empresa,
       mensaje: '',
       howFound: '',
@@ -123,6 +130,12 @@ export const ContactForm = () => {
     postContactFormMutate(contactPayload)
     postTestn8nMutate(payload, {
       onSuccess: () => {
+        if (window.gtag) {
+          window.gtag('event', 'conversion', { send_to: 'AW-17962976949/lead' })
+        }
+        if (window.fbq) {
+          window.fbq('track', 'Lead', { content_name: 'plataforma' })
+        }
         reset()
         router.push('/thankyou')
       },

--- a/src/ui/contactanos/sections/ContactForm.tsx
+++ b/src/ui/contactanos/sections/ContactForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { usePostContactForm, usePostTestn8n } from '@/lib/services/contactService'
+import { usePostContactForm } from '@/lib/services/contactService'
 import { useCountries } from '@/lib/services/countryService'
 import { useCurrencyStore } from '@/lib/store/useCurrencyStore'
 import { useToastStore } from '@/lib/store/useToastStore'
@@ -31,7 +31,6 @@ type FormData = {
 }
 
 export const ContactForm = () => {
-  const { postTestn8nMutate, isLoadingPostTestn8n } = usePostTestn8n()
   const { postContactFormMutate, isLoadingPostContactForm } = usePostContactForm()
   const { data: countries = [] } = useCountries()
   const { ipCurrency } = useCurrencyStore()
@@ -101,13 +100,6 @@ export const ContactForm = () => {
     const pais = countries?.find((c) => c.country === countrySelect)?.country_code || ''
     const telefonoConPrefijo = (countrySelect || '') + data.whatsapp
 
-    // Payload para n8n webhook
-    const payload = {
-      ...data,
-      codigo_pais: countrySelect || '',
-      pais,
-    }
-
     // Payload para API de contacto
     const contactPayload: ContactFormRequest = {
       nombre: data.nombre,
@@ -145,7 +137,6 @@ export const ContactForm = () => {
         })
       },
     })
-    postTestn8nMutate(payload)
   }
 
   return (

--- a/src/ui/contactanos/sections/ContactForm.tsx
+++ b/src/ui/contactanos/sections/ContactForm.tsx
@@ -131,7 +131,7 @@ export const ContactForm = () => {
     postTestn8nMutate(payload, {
       onSuccess: () => {
         if (window.gtag) {
-          window.gtag('event', 'conversion', { send_to: 'AW-17962976949/lead' })
+          window.gtag('event', 'conversion', { send_to: 'AW-17962976949/JNP9CMq42ZgcELWNtfVC' })
         }
         if (window.fbq) {
           window.fbq('track', 'Lead', { content_name: 'plataforma' })

--- a/src/ui/thankyou/ThankyouPage.tsx
+++ b/src/ui/thankyou/ThankyouPage.tsx
@@ -27,7 +27,6 @@ export const ThankyouPage = () => {
       origin: 'plataforma',
     })
     if (window.gtag) {
-      window.gtag('event', 'conversion', { send_to: 'AW-17962976949/signup' })
     }
     if (window.fbq) {
       window.fbq('track', 'Lead', { content_name: 'plataforma' })

--- a/src/ui/thankyou/ThankyouPage.tsx
+++ b/src/ui/thankyou/ThankyouPage.tsx
@@ -11,6 +11,7 @@ declare global {
   interface Window {
     dataLayer?: Object[]
     fbq?: (...args: unknown[]) => void
+    gtag?: (...args: unknown[]) => void
   }
 }
 
@@ -23,10 +24,13 @@ export const ThankyouPage = () => {
     }
     window.dataLayer.push({
       event: 'conversion_event_signup_2',
-      origin: 'main',
+      origin: 'plataforma',
     })
+    if (window.gtag) {
+      window.gtag('event', 'conversion', { send_to: 'AW-17962976949/signup' })
+    }
     if (window.fbq) {
-      window.fbq('track', 'Lead')
+      window.fbq('track', 'Lead', { content_name: 'plataforma' })
     }
   }, [])
 


### PR DESCRIPTION
## Qué hace este PR

1. **Bug crítico**: conversiones en `postTestn8nMutate.onSuccess` que nunca ejecutaba (N8N 404)
2. **Fix**: conversiones + `router.push('/thankyou')` movidos a `postContactFormMutate.onSuccess`
3. **N8N eliminado** del form (MVP)
4. **Botón loading** refleja estado real

## Labels verificados

- Google Ads: `AW-17962976949/JNP9CMq42ZgcELWNtfVC` (Sena - Formulario enviado, ID: 7567989834) ✅
- Meta Pixel: `fbq('track', 'Lead', { content_name: 'plataforma' })` ✅

Closes #39