### PR TITLE
fix(seo): corregir locale es_PE → es_CL en Plataforma landing

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     url: 'https://somossena.com',
     images: ['https://somossena.com/sena-crm-lite.jpg'],
     siteName: 'Sena',
-    locale: 'es_PE',
+    locale: 'es_CL',
   },
   other: {
     'facebook-domain-verification': 'tyjmxihsgkrx666ql4rwmnhsftl6hv',


### PR DESCRIPTION
## Summary
- Corrige `locale: 'es_PE'` → `'es_CL'` en OpenGraph metadata

Parte de la normalización de las 3 landings para que sean consistentes entre sí (mismo locale, URLs correctas, https en todas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)