### PR TITLE
feat(lead): HubSpot lead capture + Meta CAPI — Plataforma (feature #20)

### DIFF
--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -1,0 +1,262 @@
+import { createHash } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+type LeadPayload = {
+  nombre: string;
+  apellido: string;
+  empresa: string;
+  email: string;
+  telefono: string;
+  facturas_pendientes: string;
+  alguien_cobrando: string;
+  utmSource?: string;
+  utmMedium?: string;
+  utmCampaign?: string;
+  utmContent?: string;
+  utmTerm?: string;
+  gclid?: string;
+  fbclid?: string;
+  landingPage?: string;
+};
+
+const HS_API = "https://api.hubapi.com";
+const OWNER_FRANCISCO = "89319447";
+const PRODUCT_LIST_ID = "362";
+const INTERES_DEL_PRODUCTO = "Cuentas por Cobrar";
+
+// utm_source → valor del enum origen en HubSpot
+function mapOrigen(utmSource?: string): string {
+  const src = (utmSource ?? "").toLowerCase();
+  if (src === "google" || src === "cpc") return "Google";
+  if (src === "facebook" || src === "meta" || src === "fb") return "true"; // valor histórico de Meta
+  if (src === "linkedin") return "LinkedIn";
+  return "Orgánico";
+}
+
+// Scoring A/B/C basado en tamaño de cartera + urgencia de cobro
+function calcPrioridad(
+  facturas: string,
+  cobrando: string
+): "A" | "B" | "C" {
+  let score = 0;
+  if (facturas === "50+") score += 2;
+  else if (facturas === "10-50") score += 1;
+
+  // alguien_cobrando: el form envía "Sí" — lo normalizamos
+  const c = cobrando.toLowerCase().trim();
+  if (c === "no") score += 2;
+  else if (c === "a veces") score += 1;
+
+  if (score >= 4) return "A";
+  if (score >= 2) return "B";
+  return "C";
+}
+
+function calcSenaIntencion(p: "A" | "B" | "C"): string {
+  return p === "A" ? "Alta" : p === "B" ? "Media" : "Baja";
+}
+
+// Normaliza alguien_cobrando para el enum HubSpot ("Sí" → "Si")
+function normalizeCobrando(value: string): string {
+  const v = value.trim();
+  if (v === "Sí" || v === "Si" || v.toLowerCase() === "si") return "Si";
+  return v;
+}
+
+function getToken(): string {
+  const t = process.env.HUBSPOT_ACCESS_TOKEN;
+  if (!t) throw new Error("HUBSPOT_ACCESS_TOKEN no configurado");
+  return t;
+}
+
+async function findContactByEmail(
+  token: string,
+  email: string
+): Promise<string | null> {
+  const res = await fetch(`${HS_API}/crm/v3/objects/contacts/search`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      filterGroups: [{ filters: [{ propertyName: "email", operator: "EQ", value: email }] }],
+      properties: ["email"],
+      limit: 1,
+    }),
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.total > 0 ? data.results[0].id : null;
+}
+
+async function upsertContact(token: string, body: LeadPayload): Promise<string> {
+  const prioridad = calcPrioridad(body.facturas_pendientes, body.alguien_cobrando);
+  const origen = mapOrigen(body.utmSource);
+  const fuente = body.utmSource ? "Ads" : "Orgánico";
+
+  const properties: Record<string, string> = {
+    firstname: body.nombre,
+    lastname: body.apellido,
+    email: body.email,
+    phone: body.telefono,
+    company: body.empresa,
+    hubspot_owner_id: OWNER_FRANCISCO,
+    interes_del_producto: INTERES_DEL_PRODUCTO,
+    tipo_de_origen: "Form landing",
+    etapa_del_lead: "Interesado",
+    origen,
+    fuente_del_lead: fuente,
+    sena_prioridad: prioridad,
+    sena_intencion: calcSenaIntencion(prioridad),
+    facturas_pendientes: body.facturas_pendientes,
+    alguien_cobrando: normalizeCobrando(body.alguien_cobrando),
+    sena_contexto: `Lead landing Plataforma. Facturas: ${body.facturas_pendientes}. Cobrando: ${body.alguien_cobrando}. Prioridad auto: ${prioridad}. Origen: ${origen}.`,
+  };
+
+  if (body.gclid) properties.gclid = body.gclid;
+  if (body.fbclid) properties.fbclid = body.fbclid;
+  if (body.landingPage) properties.landing_page = body.landingPage;
+  if (body.utmCampaign) properties.utm_campaign = body.utmCampaign;
+  if (body.utmTerm) properties.utm_term = body.utmTerm;
+
+  const existingId = await findContactByEmail(token, body.email);
+
+  if (existingId) {
+    const res = await fetch(`${HS_API}/crm/v3/objects/contacts/${existingId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ properties }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(`PATCH contact failed: ${JSON.stringify(err)}`);
+    }
+    return existingId;
+  }
+
+  const res = await fetch(`${HS_API}/crm/v3/objects/contacts`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ properties }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(`POST contact failed: ${JSON.stringify(err)}`);
+  }
+  const data = await res.json();
+  return data.id;
+}
+
+async function createDeal(token: string, contactId: string, body: LeadPayload): Promise<void> {
+  const prioridad = calcPrioridad(body.facturas_pendientes, body.alguien_cobrando);
+
+  const res = await fetch(`${HS_API}/crm/v3/objects/deals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      properties: {
+        dealname: `Plataforma — ${body.empresa}`,
+        dealstage: "appointmentscheduled",
+        pipeline: "default",
+        hubspot_owner_id: OWNER_FRANCISCO,
+        closedate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split("T")[0],
+        description: `Prioridad: ${prioridad} · Facturas: ${body.facturas_pendientes} · Cobrando: ${body.alguien_cobrando}`,
+      },
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(`POST deal failed: ${JSON.stringify(err)}`);
+  }
+  const deal = await res.json();
+
+  await fetch(`${HS_API}/crm/v3/objects/deals/${deal.id}/associations/contacts/${contactId}/3`, {
+    method: "PUT",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+async function addToList(token: string, contactId: string): Promise<void> {
+  await fetch(`${HS_API}/crm/v3/lists/${PRODUCT_LIST_ID}/memberships/add`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify([contactId]),
+  });
+}
+
+async function sendMetaCapi(body: LeadPayload): Promise<void> {
+  const pixelId = process.env.META_PIXEL_ID;
+  const capiToken = process.env.META_CAPI_TOKEN;
+  if (!pixelId || !capiToken) return;
+
+  const hashedEmail = createHash("sha256")
+    .update(body.email.toLowerCase().trim())
+    .digest("hex");
+
+  const userData: Record<string, string | string[]> = {
+    em: [hashedEmail],
+  };
+  if (body.fbclid) userData.fbc = `fb.1.${Date.now()}.${body.fbclid}`;
+
+  try {
+    await fetch(
+      `https://graph.facebook.com/v21.0/${pixelId}/events?access_token=${capiToken}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          data: [
+            {
+              event_name: "Lead",
+              event_time: Math.floor(Date.now() / 1000),
+              action_source: "website",
+              user_data: userData,
+              custom_data: {
+                content_name: "plataforma",
+                utm_source: body.utmSource,
+                utm_campaign: body.utmCampaign,
+              },
+            },
+          ],
+        }),
+        signal: AbortSignal.timeout(5000),
+      }
+    );
+  } catch (err) {
+    console.error("[CAPI] error:", err);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  let token: string;
+  try {
+    token = getToken();
+  } catch {
+    return NextResponse.json({ error: "HubSpot no configurado" }, { status: 500 });
+  }
+
+  let body: LeadPayload;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Payload inválido" }, { status: 400 });
+  }
+
+  const { nombre, apellido, empresa, email, telefono, facturas_pendientes, alguien_cobrando } =
+    body;
+  if (!nombre || !apellido || !empresa || !email || !telefono || !facturas_pendientes || !alguien_cobrando) {
+    return NextResponse.json({ error: "Faltan campos requeridos" }, { status: 400 });
+  }
+
+  // Meta CAPI corre en paralelo — fire-and-forget, no bloquea
+  const capiPromise = sendMetaCapi(body);
+
+  try {
+    const contactId = await upsertContact(token, body);
+    await Promise.all([createDeal(token, contactId, body), addToList(token, contactId)]);
+    await capiPromise;
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[HubSpot] error:", err);
+    await capiPromise;
+    return NextResponse.json({ ok: true, warning: "CRM sync pendiente" });
+  }
+}

--- a/src/ui/contactanos/sections/ContactForm.tsx
+++ b/src/ui/contactanos/sections/ContactForm.tsx
@@ -13,6 +13,13 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 
+declare global {
+  interface Window {
+    fbq?: (...args: unknown[]) => void
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
 type FormData = {
   nombre: string
   apellido: string
@@ -37,6 +44,9 @@ export const ContactForm = () => {
   const utmMedium = searchParams?.get('utm_medium') || null
   const utmCampaign = searchParams?.get('utm_campaign') || null
   const utmContent = searchParams?.get('utm_content') || null
+  const utmTerm = searchParams?.get('utm_term') || null
+  const [gclid, setGclid] = useState<string | null>(null)
+  const [fbclid, setFbclid] = useState<string | null>(null)
 
   const countryOptions = useMemo(() => {
     if (!countries.length) return []
@@ -73,6 +83,14 @@ export const ContactForm = () => {
     }
   }, [ipCurrency])
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const gc = params.get('gclid') || sessionStorage.getItem('gclid')
+    const fb = params.get('fbclid') || sessionStorage.getItem('fbclid')
+    if (gc) { setGclid(gc); sessionStorage.setItem('gclid', gc) }
+    if (fb) { setFbclid(fb); sessionStorage.setItem('fbclid', fb) }
+  }, [])
+
   const {
     control,
     handleSubmit,
@@ -101,7 +119,30 @@ export const ContactForm = () => {
       pais,
     }
 
-    // Payload para API de contacto
+    // Fire-and-forget HubSpot sync
+    fetch('/api/lead', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nombre: data.nombre,
+        apellido: data.apellido,
+        empresa: data.empresa,
+        email: data.email,
+        telefono: telefonoConPrefijo,
+        facturas_pendientes: data.facturas_pendientes,
+        alguien_cobrando: data.alguien_cobrando,
+        utmSource: utmSource ?? undefined,
+        utmMedium: utmMedium ?? undefined,
+        utmCampaign: utmCampaign ?? undefined,
+        utmContent: utmContent ?? undefined,
+        utmTerm: utmTerm ?? undefined,
+        gclid: gclid ?? undefined,
+        fbclid: fbclid ?? undefined,
+        landingPage: window.location.pathname,
+      }),
+    }).catch(() => {})
+
+    // Fire-and-forget Django API sync
     const contactPayload: ContactFormRequest = {
       nombre: data.nombre,
       apellido: data.apellido,
@@ -109,7 +150,7 @@ export const ContactForm = () => {
       telefono: telefonoConPrefijo,
       formOrigin: 'Formulario de Registro',
       countryName: pais,
-      productType: 'main',
+      productType: 'plataforma',
       nombreEmpresa: data.empresa,
       mensaje: '',
       howFound: '',
@@ -118,11 +159,16 @@ export const ContactForm = () => {
       utmCampaign: utmCampaign || undefined,
       utmContent: utmContent || undefined,
     }
-
-    // Llamar ambas APIs
     postContactFormMutate(contactPayload)
+
     postTestn8nMutate(payload, {
       onSuccess: () => {
+        if (window.gtag) {
+          window.gtag('event', 'conversion', { send_to: 'AW-17962976949/JNP9CMq42ZgcELWNtfVC' })
+        }
+        if (window.fbq) {
+          window.fbq('track', 'Lead', { content_name: 'plataforma' })
+        }
         reset()
         router.push('/thankyou')
       },

--- a/src/ui/thankyou/ThankyouPage.tsx
+++ b/src/ui/thankyou/ThankyouPage.tsx
@@ -23,7 +23,7 @@ export const ThankyouPage = () => {
     }
     window.dataLayer.push({
       event: 'conversion_event_signup_2',
-      origin: 'main',
+      origin: 'plataforma',
     })
     if (window.fbq) {
       window.fbq('track', 'Lead')


### PR DESCRIPTION
Closes #20

## Tasks incluidas
- Closes #21 — feat: src/app/api/lead/route.ts (HubSpot upsert + deal + lista 362 + Meta CAPI)
- Closes #22 — feat: ContactForm.tsx (fire-and-forget /api/lead + gclid/fbclid + utmTerm)
- Closes #23 — fix: ThankyouPage.tsx (origin 'main' → 'plataforma' en dataLayer)

## Resumen
- Nueva API route `/api/lead`: upserta contacto en HubSpot, crea deal, agrega a lista 362 (Plataforma), y dispara evento Lead a Meta CAPI server-side con email SHA-256
- Scoring A/B/C automático basado en facturas_pendientes + alguien_cobrando; campo `sena_prioridad` + `sena_intencion` en HubSpot
- ContactForm captura gclid/fbclid desde URL/sessionStorage y los envía junto con todos los UTMs al endpoint HubSpot (fire-and-forget — no bloquea al usuario)
- `productType` corregido a 'plataforma' en todos los tracking events

## Env vars requeridas en Vercel (sena-landing)
- `HUBSPOT_ACCESS_TOKEN` — PAT con scopes: crm.objects.contacts, crm.objects.deals, crm.lists.write, crm.lists.read
- `META_PIXEL_ID` — Pixel ID de Plataforma
- `META_CAPI_TOKEN` — Token del dataset Meta CAPI

## Test plan
- [ ] Agregar env vars en Vercel antes de deploy
- [ ] Enviar form de prueba → verificar contacto/deal en HubSpot con prioridad correcta
- [ ] Verificar evento Lead en Meta Events Manager
- [ ] Verificar que gclid/fbclid se guarda en HubSpot cuando vienen en URL