### PR TITLE
fix(lead): security — capi token en body, email validation, sanitize logs

### DIFF
--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -198,11 +198,12 @@ async function sendMetaCapi(body: LeadPayload): Promise<void> {
 
   try {
     await fetch(
-      `https://graph.facebook.com/v21.0/${pixelId}/events?access_token=${capiToken}`,
+      `https://graph.facebook.com/v21.0/${pixelId}/events`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          access_token: capiToken,
           data: [
             {
               event_name: "Lead",
@@ -221,7 +222,7 @@ async function sendMetaCapi(body: LeadPayload): Promise<void> {
       }
     );
   } catch (err) {
-    console.error("[CAPI] error:", err);
+    console.error("[CAPI] error:", err instanceof Error ? err.message : "CAPI error");
   }
 }
 
@@ -246,6 +247,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Faltan campos requeridos" }, { status: 400 });
   }
 
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return NextResponse.json({ error: "Email inválido" }, { status: 400 });
+  }
+
   // Meta CAPI corre en paralelo — fire-and-forget, no bloquea
   const capiPromise = sendMetaCapi(body);
 
@@ -255,7 +261,7 @@ export async function POST(req: NextRequest) {
     await capiPromise;
     return NextResponse.json({ ok: true });
   } catch (err) {
-    console.error("[HubSpot] error:", err);
+    console.error("[HubSpot] error:", err instanceof Error ? err.message : "CRM error");
     await capiPromise;
     return NextResponse.json({ ok: true, warning: "CRM sync pendiente" });
   }


### PR DESCRIPTION
CAPI token movido de query string a POST body (OWASP A02). Email validation server-side. Sanitizacion de logs. No breaking changes.