### PR TITLE
fix(lead): mapOrigen Meta value 'true' → 'Meta'

### DIFF
--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -28,7 +28,7 @@ const INTERES_DEL_PRODUCTO = "Cuentas por Cobrar";
 function mapOrigen(utmSource?: string): string {
   const src = (utmSource ?? "").toLowerCase();
   if (src === "google" || src === "cpc") return "Google";
-  if (src === "facebook" || src === "meta" || src === "fb") return "true"; // valor histórico de Meta
+  if (src === "facebook" || src === "meta" || src === "fb") return "Meta";
   if (src === "linkedin") return "LinkedIn";
   return "Orgánico";
 }


### PR DESCRIPTION
## Problema

La función `mapOrigen` en `/api/lead/route.ts` devolvía el string `"true"` para leads de Meta/Facebook, en lugar de `"Meta"`. Esto provocaba que el campo `origen` en HubSpot quedara con un valor que no matchea ninguna opción válida del enum, rompiendo filtros, listas y reportes de atribución.

## Fix

```diff
- if (src === "facebook" || src === "meta" || src === "fb") return "true";
+ if (src === "facebook" || src === "meta" || src === "fb") return "Meta";
```

## Contexto

El enum `origen` en HubSpot fue corregido en paralelo vía PATCH a la Properties API (el value histórico `"true"` fue renombrado a `"Meta"`). Este PR alinea el código para que ambos lados sean consistentes.

## Test plan

- [ ] Completar el formulario desde una URL con `?utm_source=meta` y verificar que el contacto creado en HubSpot tenga `origen = "Meta"`
- [ ] Mismo test con `?utm_source=facebook` y `?utm_source=fb`
- [ ] Verificar que leads sin `utm_source` siguen llegando como `origen = "Orgánico"`
- [ ] Verificar que leads con `utm_source=google` llegan como `origen = "Google"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)