### PR TITLE
fix(lead): PRODUCT_LIST_ID 362 → 217 (Sena - Leads Plataforma)

### DIFF
--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -21,7 +21,7 @@ type LeadPayload = {
 
 const HS_API = "https://api.hubapi.com";
 const OWNER_FRANCISCO = "89319447";
-const PRODUCT_LIST_ID = "362";
+const PRODUCT_LIST_ID = "217";
 const INTERES_DEL_PRODUCTO = "Cuentas por Cobrar";
 
 // utm_source → valor del enum origen en HubSpot


### PR DESCRIPTION
## Problema

`PRODUCT_LIST_ID` estaba seteado en `"362"`, un ID que no existe en HubSpot. Al hacer submit del formulario, la llamada `addToList` caía en silencio sin agregar el contacto a ninguna lista.

La lista correcta es la **#217 "Sena - Leads Plataforma"** (estática, creada en HubSpot).

## Fix

```diff
- const PRODUCT_LIST_ID = "362";
+ const PRODUCT_LIST_ID = "217";
```

## Test plan

- [ ] Completar el formulario y verificar que el nuevo contacto aparece en la lista #217 "Sena - Leads Plataforma" en HubSpot
- [ ] Verificar que el deal se crea y queda asociado al contacto

🤖 Generated with [Claude Code](https://claude.com/claude-code)