### PR TITLE
debug: exponer error HubSpot para diagnóstico (revertir después)

### DIFF
--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -263,6 +263,6 @@ export async function POST(req: NextRequest) {
   } catch (err) {
     console.error("[HubSpot] error:", err instanceof Error ? err.message : "CRM error");
     await capiPromise;
-    return NextResponse.json({ ok: true, warning: "CRM sync pendiente" });
+    return NextResponse.json({ ok: true, warning: err instanceof Error ? err.message : "CRM sync pendiente" });
   }
 }


### PR DESCRIPTION
PR temporal de debug. Expone el mensaje de error real en lugar de 'CRM sync pendiente' para identificar por qué las llamadas a HubSpot fallan desde Vercel. **Revertir inmediatamente después del diagnóstico.**