### PR TITLE
fix(tracking): eliminar GA4 inline duplicado en sena-landing

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -69,7 +69,6 @@ export default async function RootLayout({
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
               gtag('config', 'AW-17962976949');
-              gtag('config', 'G-BENT3HE0M6');
             `}
           </Script>
           {/* Meta Pixel — Plataforma (1722871789075263) */}


### PR DESCRIPTION
## Problema

somossena.com tenía dos GA4 IDs cargando simultáneamente:

- **G-BENT3HE0M6** — inyectado inline en `layout.tsx` dentro del mismo script de Google Ads
- **G-525400378** — inyectado por el container GTM-5W7F9MSP

Esto causa que cada pageview dispare hits a **dos propiedades GA4 distintas**, fragmentando los datos de analítica.

## Causa raíz

El script inline de Google Ads (`AW-17962976949`) tenía un `gtag('config', 'G-BENT3HE0M6')` pegado al final — probablemente copiado de la documentación de instalación de GA4 sin considerar que GTM ya lo cargaba.

## Fix

Eliminar `gtag('config', 'G-BENT3HE0M6')` del script inline. El tag de Google Ads (`AW-17962976949`) permanece porque maneja conversiones y requiere carga directa.

**GA4 debe cargarse exclusivamente via GTM** — un solo lugar, una sola propiedad activa.

## Verificación post-merge

1. Abrir somossena.com con GA4 DebugView activo
2. Confirmar que solo `G-525400378` (via GTM) recibe hits
3. Confirmar que `G-BENT3HE0M6` ya no aparece en Network tab

Closes #(pendiente crear issue si se requiere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)