### PR TITLE
fix(tracking): atribución gclid/fbclid + landingPage URL completa

### DIFF
--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -25,7 +25,9 @@ const PRODUCT_LIST_ID = "362";
 const INTERES_DEL_PRODUCTO = "Cuentas por Cobrar";
 
 // utm_source → valor del enum origen en HubSpot
-function mapOrigen(utmSource?: string): string {
+function mapOrigen(utmSource?: string, gclid?: string, fbclid?: string): string {
+  if (gclid) return "Google"
+  if (fbclid) return "Meta"
   const src = (utmSource ?? "").toLowerCase();
   if (src === "google" || src === "cpc") return "Google";
   if (src === "facebook" || src === "meta" || src === "fb") return "Meta";
@@ -89,8 +91,11 @@ async function findContactByEmail(
 
 async function upsertContact(token: string, body: LeadPayload): Promise<string> {
   const prioridad = calcPrioridad(body.facturas_pendientes, body.alguien_cobrando);
-  const origen = mapOrigen(body.utmSource);
-  const fuente = body.utmSource ? "Ads" : "Orgánico";
+  const origen = mapOrigen(body.utmSource, body.gclid, body.fbclid);
+  const fuente = body.gclid ? "Google Ads"
+    : body.fbclid ? "Meta Ads"
+    : body.utmSource ? "Ads"
+    : "Orgánico";
 
   const properties: Record<string, string> = {
     firstname: body.nombre,

--- a/src/ui/contactanos/sections/ContactForm.tsx
+++ b/src/ui/contactanos/sections/ContactForm.tsx
@@ -130,7 +130,7 @@ export const ContactForm = () => {
         utmTerm: utmTerm ?? undefined,
         gclid: gclid ?? undefined,
         fbclid: fbclid ?? undefined,
-        landingPage: window.location.pathname,
+        landingPage: window.location.href,
       }),
     }).catch(() => {})
     const contactPayload: ContactFormRequest = {


### PR DESCRIPTION
## Fixes incluidos

### Bug #155 — fuente_del_lead siempre "Orgánico"
`route.ts` — `mapOrigen` y `fuente` ahora detectan `gclid` y `fbclid`.

### Bug #156 — landing_page capturaba "/"
`ContactForm.tsx` — `window.location.pathname` → `window.location.href`

Part of feature #38 / Closes #155 / Closes #156