### PR TITLE
fix(pricing): agrega label DESDE en precio Enterprise

### DIFF
--- a/src/ui/home/sections/PricingPlans/PlanCard.tsx
+++ b/src/ui/home/sections/PricingPlans/PlanCard.tsx
@@ -39,6 +39,9 @@ export const PlanCard = ({ plan }: { plan: TPlan }) => {
 
       {/* Price */}
       <div>
+        {isEnterprise && (
+          <p className="text-xs font-bold text-brand-primary uppercase tracking-wide mb-0.5">Desde</p>
+        )}
         <p className="text-brand-primary flex items-center">
           <span className="text-xl font-extrabold mr-2">USD </span>
           <span className="text-5xl font-extrabold">{plan.price}</span>


### PR DESCRIPTION
## Summary
- Agrega etiqueta "DESDE" encima de USD 799/mes en el Plan Enterprise
- Comunica que el precio es base, no fijo — Starter y Growth sin cambios

## Test plan
- [x] Verificado visualmente con Playwright headless

🤖 Generated with [Claude Code](https://claude.com/claude-code)