### PR TITLE
fix(ui): footer copyright + blog post destacado

### DIFF
--- a/src/lib/data/blogPosts.ts
+++ b/src/lib/data/blogPosts.ts
@@ -2,7 +2,7 @@ import { BlogPost } from '../types/blog'
 import { AssetImageBlog } from '../utils/assets/imageBlog'
 import { parseSpanishDate, slug } from '../utils/blog'
 
-export const featuredPostId = 1
+export const featuredPostId = 33
 
 export const blogPosts: BlogPost[] = [
   // {

--- a/src/ui/layout/Footer.tsx
+++ b/src/ui/layout/Footer.tsx
@@ -196,7 +196,7 @@ export const Footer = () => {
         {/* Mobile: Bottom bar */}
         <div className="md:hidden">
           <div className="border-t border-white/30 pt-6 flex justify-between items-center">
-            <p className="text-xs">© SENA SE 2026</p>
+            <p className="text-xs">© Sena 2026</p>
             <img
               className="w-20 cursor-pointer"
               src={AssetImage.byRecsa.src}
@@ -325,7 +325,7 @@ export const Footer = () => {
 
         {/* Desktop: Bottom bar */}
         <div className="hidden md:flex flex-row justify-between items-center pt-8 gap-4">
-          <p className="text-sm">© SENA SE 2026</p>
+          <p className="text-sm">© Sena 2026</p>
 
           <div className="flex gap-6">
             <a


### PR DESCRIPTION
## Cambios

- **Footer**: `© SENA SE 2026` → `© Sena 2026` (mobile y desktop). "SENA SE" no es marca registrada ni tiene sentido como texto público.
- **Blog**: `featuredPostId` 1→33 — el id 1 no existe en el array, por lo que se mostraba el primero del array (dic 2025). Ahora se pina el post más reciente: "Tu equipo vende, pero ¿quién cobra?" (17 de abril 2026).

Closes #250 (parcial — blog y footer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)