### PR TITLE
release: plataforma landing ads + fixes footer/blog

### DIFF
--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -187,6 +187,33 @@ async function addToList(token: string, contactId: string): Promise<void> {
   });
 }
 
+async function notifyN8N(body: LeadPayload, prioridad: "A" | "B" | "C"): Promise<void> {
+  const webhookUrl = process.env.N8N_WEBHOOK_PLATAFORMA_LEAD
+  if (!webhookUrl) return
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        product: "plataforma",
+        nombre: body.nombre,
+        empresa: body.empresa,
+        email: body.email,
+        whatsapp: body.telefono,
+        prioridad,
+        gclid: body.gclid,
+        utm_source: body.utmSource,
+        utm_campaign: body.utmCampaign,
+        landing_page: body.landingPage,
+        _env: process.env.APP_ENV || "dev",
+      }),
+      signal: AbortSignal.timeout(5000),
+    })
+  } catch (err) {
+    console.error("[N8N] webhook error:", err instanceof Error ? err.message : "N8N error")
+  }
+}
+
 async function sendMetaCapi(body: LeadPayload): Promise<void> {
   const pixelId = process.env.META_PIXEL_ID;
   const capiToken = process.env.META_CAPI_TOKEN;
@@ -257,17 +284,19 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Email inválido" }, { status: 400 });
   }
 
-  // Meta CAPI corre en paralelo — fire-and-forget, no bloquea
+  // Fire-and-forget: CAPI + N8N corren en paralelo, no bloquean al usuario
+  const prioridad = calcPrioridad(body.facturas_pendientes, body.alguien_cobrando);
   const capiPromise = sendMetaCapi(body);
+  const n8nPromise = notifyN8N(body, prioridad);
 
   try {
     const contactId = await upsertContact(token, body);
     await Promise.all([createDeal(token, contactId, body), addToList(token, contactId)]);
-    await capiPromise;
+    await Promise.allSettled([capiPromise, n8nPromise]);
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("[HubSpot] error:", err instanceof Error ? err.message : "CRM error");
-    await capiPromise;
+    await Promise.allSettled([capiPromise, n8nPromise]);
     return NextResponse.json({ ok: true, warning: "CRM sync pendiente" });
   }
 }

--- a/src/app/api/lead/route.ts
+++ b/src/app/api/lead/route.ts
@@ -187,33 +187,6 @@ async function addToList(token: string, contactId: string): Promise<void> {
   });
 }
 
-async function notifyN8N(body: LeadPayload, prioridad: "A" | "B" | "C"): Promise<void> {
-  const webhookUrl = process.env.N8N_WEBHOOK_PLATAFORMA_LEAD
-  if (!webhookUrl) return
-  try {
-    await fetch(webhookUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        product: "plataforma",
-        nombre: body.nombre,
-        empresa: body.empresa,
-        email: body.email,
-        whatsapp: body.telefono,
-        prioridad,
-        gclid: body.gclid,
-        utm_source: body.utmSource,
-        utm_campaign: body.utmCampaign,
-        landing_page: body.landingPage,
-        _env: process.env.APP_ENV || "dev",
-      }),
-      signal: AbortSignal.timeout(5000),
-    })
-  } catch (err) {
-    console.error("[N8N] webhook error:", err instanceof Error ? err.message : "N8N error")
-  }
-}
-
 async function sendMetaCapi(body: LeadPayload): Promise<void> {
   const pixelId = process.env.META_PIXEL_ID;
   const capiToken = process.env.META_CAPI_TOKEN;
@@ -284,19 +257,16 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Email inválido" }, { status: 400 });
   }
 
-  // Fire-and-forget: CAPI + N8N corren en paralelo, no bloquean al usuario
-  const prioridad = calcPrioridad(body.facturas_pendientes, body.alguien_cobrando);
   const capiPromise = sendMetaCapi(body);
-  const n8nPromise = notifyN8N(body, prioridad);
 
   try {
     const contactId = await upsertContact(token, body);
     await Promise.all([createDeal(token, contactId, body), addToList(token, contactId)]);
-    await Promise.allSettled([capiPromise, n8nPromise]);
+    await capiPromise;
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("[HubSpot] error:", err instanceof Error ? err.message : "CRM error");
-    await Promise.allSettled([capiPromise, n8nPromise]);
+    await capiPromise;
     return NextResponse.json({ ok: true, warning: "CRM sync pendiente" });
   }
 }

--- a/src/app/plataforma/gracias/page.tsx
+++ b/src/app/plataforma/gracias/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+import { PlataformaGraciasPage } from '@/ui/plataforma/PlataformaGraciasPage'
+
+export const metadata: Metadata = {
+  title: 'Solicitud recibida | Sena Plataforma',
+  robots: { index: false, follow: false },
+}
+
+const PlataformaGracias = () => {
+  return <PlataformaGraciasPage />
+}
+
+export default PlataformaGracias

--- a/src/app/plataforma/layout.tsx
+++ b/src/app/plataforma/layout.tsx
@@ -1,0 +1,3 @@
+export default function PlataformaLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/plataforma/page.tsx
+++ b/src/app/plataforma/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next'
+import { PlataformaPage } from '@/ui/plataforma/PlataformaPage'
+
+export const metadata: Metadata = {
+  title: 'Software de Cobranza B2B para Empresas en Chile | Sena Plataforma',
+  description:
+    'Automatiza tu cobranza B2B con Sena. Visibilidad total de tu cartera, recordatorios automáticos y conciliación sin reemplazar tu tech stack. Agenda demo gratis.',
+  keywords:
+    'software cobranza b2b, plataforma cobranza chile, automatizar cobranza empresas, cuentas por cobrar b2b, gestion cartera vencida, crm cobranza chile',
+  robots: { index: true, follow: true },
+  alternates: { canonical: 'https://www.somossena.com/plataforma' },
+  openGraph: {
+    title: 'Software de Cobranza B2B para Empresas en Chile | Sena',
+    description:
+      'Automatiza tu cobranza B2B. Visibilidad total, recordatorios automáticos y conciliación sin cambiar tu stack.',
+    url: 'https://www.somossena.com/plataforma',
+    type: 'website',
+    images: ['https://somossena.com/sena-crm-lite.jpg'],
+    siteName: 'Sena',
+    locale: 'es_CL',
+  },
+}
+
+const Page = () => <PlataformaPage />
+
+export default Page

--- a/src/lib/data/blogPosts.ts
+++ b/src/lib/data/blogPosts.ts
@@ -2,7 +2,7 @@ import { BlogPost } from '../types/blog'
 import { AssetImageBlog } from '../utils/assets/imageBlog'
 import { parseSpanishDate, slug } from '../utils/blog'
 
-export const featuredPostId = 1
+export const featuredPostId = 33
 
 export const blogPosts: BlogPost[] = [
   // {

--- a/src/ui/layout/Footer.tsx
+++ b/src/ui/layout/Footer.tsx
@@ -196,7 +196,7 @@ export const Footer = () => {
         {/* Mobile: Bottom bar */}
         <div className="md:hidden">
           <div className="border-t border-white/30 pt-6 flex justify-between items-center">
-            <p className="text-xs">© SENA SE 2026</p>
+            <p className="text-xs">© Sena 2026</p>
             <img
               className="w-20 cursor-pointer"
               src={AssetImage.byRecsa.src}
@@ -325,7 +325,7 @@ export const Footer = () => {
 
         {/* Desktop: Bottom bar */}
         <div className="hidden md:flex flex-row justify-between items-center pt-8 gap-4">
-          <p className="text-sm">© SENA SE 2026</p>
+          <p className="text-sm">© Sena 2026</p>
 
           <div className="flex gap-6">
             <a

--- a/src/ui/plataforma/PlataformaGraciasPage.tsx
+++ b/src/ui/plataforma/PlataformaGraciasPage.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { AssetImage } from '@/lib/utils/assets/image'
+import Image from 'next/image'
+import Link from 'next/link'
+import Script from 'next/script'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+    fbq?: (...args: unknown[]) => void
+    dataLayer?: Object[]
+  }
+}
+
+export const PlataformaGraciasPage = () => {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!window.dataLayer) window.dataLayer = []
+    window.dataLayer.push({ event: 'conversion_event_signup_2', origin: 'plataforma' })
+    if (window.gtag) {
+      window.gtag('event', 'completar_formulario', { product: 'plataforma' })
+      window.gtag('event', 'conversion', { send_to: 'AW-17962976949/JNP9CMq42ZgcELWNtfVC' })
+    }
+    if (window.fbq) window.fbq('track', 'Lead', { content_name: 'plataforma' })
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-[#F9F9F9] flex flex-col">
+      <div className="w-full py-6 flex justify-center">
+        <button onClick={() => router.push('/')} className="cursor-pointer">
+          <Image src={AssetImage.logoBlack} alt="Sena" className="w-36" />
+        </button>
+      </div>
+
+      <div className="flex-1 flex items-start justify-center px-4 pb-16">
+        <div className="w-full max-w-2xl">
+          {/* Success card */}
+          <div className="bg-white rounded-3xl shadow-[0_8px_40px_rgba(0,0,0,0.06)] border border-slate-100 overflow-hidden mb-6">
+            <div className="h-1.5 bg-linear-to-r from-brand-primary via-brand-primary to-brand-secondary" />
+            <div className="px-8 pt-8 pb-6 md:px-12 text-center">
+              <div className="flex justify-center mb-5">
+                <div className="w-14 h-14 rounded-full bg-green-50 border-2 border-green-200 flex items-center justify-center">
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
+                    <path d="M20 6L9 17L4 12" stroke="#22c55e" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </div>
+              </div>
+              <h1 className="font-canaro text-brand-primary-dark text-2xl md:text-3xl font-extrabold leading-tight mb-2">
+                ¡Recibimos tu solicitud!
+              </h1>
+              <p className="text-slate-600 text-sm md:text-base leading-relaxed mb-1">
+                Nuestro equipo te contactará pronto.
+              </p>
+              <p className="text-brand-primary-dark text-sm md:text-base font-bold leading-relaxed mb-6">
+                Si prefieres avanzar ahora, agenda tu demo directamente:
+              </p>
+            </div>
+          </div>
+
+          {/* HubSpot inline calendar */}
+          <div className="bg-white rounded-3xl shadow-[0_8px_40px_rgba(0,0,0,0.06)] border border-slate-100 overflow-hidden mb-6">
+            <div className="px-4 pt-6 pb-2 text-center">
+              <p className="text-xs text-slate-400 font-medium mb-4">Agenda tu demo de 30 minutos</p>
+            </div>
+            <div
+              className="meetings-iframe-container w-full"
+              style={{ minHeight: 620 }}
+              data-src="https://meetings.hubspot.com/francisco502?embed=true"
+            />
+          </div>
+
+          {/* Fallback link */}
+          <div className="text-center mb-8">
+            <Link
+              href="https://meetings.hubspot.com/francisco502"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand-primary text-sm font-semibold hover:underline"
+            >
+              Abrir calendario en nueva pestaña →
+            </Link>
+          </div>
+
+          {/* Footer */}
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex items-center gap-6 text-slate-400 text-xs">
+              <span>Sin compromiso</span>
+              <span>·</span>
+              <span>30 min</span>
+              <span>·</span>
+              <span>Equipo experto</span>
+            </div>
+            <button
+              onClick={() => router.push('/plataforma')}
+              className="text-brand-primary text-sm font-semibold hover:underline cursor-pointer flex items-center gap-1"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                <path d="M19 12H5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                <path d="M12 19L5 12L12 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              Volver a la landing
+            </button>
+            <p className="text-slate-300 text-xs mt-2">
+              Sena — <span className="font-caslon">El arte de cobrar bien</span>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <Script
+        src="https://static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js"
+        strategy="lazyOnload"
+      />
+    </div>
+  )
+}

--- a/src/ui/plataforma/PlataformaPage.tsx
+++ b/src/ui/plataforma/PlataformaPage.tsx
@@ -4,8 +4,9 @@ import Button from '@/ui/shared/Button'
 import { AssetImage } from '@/lib/utils/assets/image'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { ArrowRight, CheckCircle, BarChart2, Zap, Eye } from 'lucide-react'
+import { PlataformaContactForm } from './sections/PlataformaContactForm'
 
 const StickyMobileCTA = () => {
   const [visible, setVisible] = useState(true)
@@ -223,21 +224,22 @@ export const PlataformaPage = () => {
           </div>
         </section>
 
-        {/* Contact form section — placeholder; form se agrega en task #230 */}
+        {/* Contact form — inline above fold */}
         <section id="contacto" className="py-12 md:py-20">
           <div className="max-w-[1280px] mx-auto px-4">
-            <div className="max-w-lg mx-auto text-center">
-              <h2 className="text-brand-primary-dark text-2xl md:text-4xl font-extrabold mb-3">
-                Agenda tu demo de{' '}
-                <span className="text-brand-primary">30 minutos</span>
-              </h2>
-              <p className="text-slate-500 mb-8">
-                Sin compromiso. Te mostramos cómo funciona con tu cartera real.
-              </p>
-              {/* Form: task #230 */}
-              <div className="bg-white rounded-2xl shadow-sm border border-slate-100 p-8">
-                <p className="text-slate-400 text-sm">Formulario de contacto — próxima task</p>
+            <div className="max-w-xl mx-auto">
+              <div className="text-center mb-8">
+                <h2 className="text-brand-primary-dark text-2xl md:text-4xl font-extrabold mb-3">
+                  Agenda tu demo de{' '}
+                  <span className="text-brand-primary">30 minutos</span>
+                </h2>
+                <p className="text-slate-500">
+                  Sin compromiso. Te mostramos cómo funciona con tu cartera real.
+                </p>
               </div>
+              <Suspense>
+                <PlataformaContactForm />
+              </Suspense>
             </div>
           </div>
         </section>

--- a/src/ui/plataforma/PlataformaPage.tsx
+++ b/src/ui/plataforma/PlataformaPage.tsx
@@ -1,0 +1,269 @@
+'use client'
+
+import Button from '@/ui/shared/Button'
+import { AssetImage } from '@/lib/utils/assets/image'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { ArrowRight, CheckCircle, BarChart2, Zap, Eye } from 'lucide-react'
+
+const StickyMobileCTA = () => {
+  const [visible, setVisible] = useState(true)
+
+  useEffect(() => {
+    const form = document.getElementById('contacto')
+    if (!form) return
+    const observer = new IntersectionObserver(([entry]) => setVisible(!entry.isIntersecting), {
+      threshold: 0,
+    })
+    observer.observe(form)
+    return () => observer.disconnect()
+  }, [])
+
+  const scrollToForm = () => {
+    const el = document.getElementById('contacto')
+    if (!el) return
+    window.scrollTo({ top: el.getBoundingClientRect().top + window.pageYOffset - 72, behavior: 'smooth' })
+  }
+
+  if (!visible) return null
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 bg-white border-t border-slate-200 shadow-[0_-4px_16px_rgba(0,0,0,0.08)] md:hidden">
+      <button
+        onClick={scrollToForm}
+        className="w-full flex items-center justify-center gap-2 bg-brand-primary text-white font-bold py-3.5 px-6 rounded-xl text-base active:scale-[0.98] transition-transform"
+      >
+        Agenda demo gratuito
+        <ArrowRight className="h-5 w-5" />
+      </button>
+    </div>
+  )
+}
+
+export const PlataformaPage = () => {
+  const scrollToForm = () => {
+    const el = document.getElementById('contacto')
+    if (!el) return
+    window.scrollTo({ top: el.getBoundingClientRect().top + window.pageYOffset - 72, behavior: 'smooth' })
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-[#F9F9F9]">
+      {/* Header minimal — solo logo + teléfono */}
+      <header className="w-full bg-white border-b border-slate-100 px-4 py-3">
+        <div className="max-w-[1280px] mx-auto flex items-center justify-between">
+          <Link href="/">
+            <Image src={AssetImage.logoBlack} alt="Sena" className="h-7 w-auto" />
+          </Link>
+          <a
+            href="tel:+56944489673"
+            className="text-sm font-semibold text-brand-primary-dark hover:text-brand-primary transition-colors"
+          >
+            +56 9 4448 9673
+          </a>
+        </div>
+      </header>
+
+      <main className="flex-1">
+        {/* Hero */}
+        <section className="max-w-[1280px] mx-auto px-4 py-12 md:py-20">
+          <div className="max-w-3xl mx-auto text-center">
+            <div className="inline-flex items-center gap-2 bg-brand-primary/10 text-brand-primary-dark text-xs font-bold px-3 py-1.5 rounded-full mb-6">
+              Software de cobranza B2B para empresas en Chile
+            </div>
+
+            <h1 className="font-canaro text-brand-primary-dark text-3xl md:text-5xl lg:text-6xl font-extrabold leading-tight mb-4">
+              Automatiza tu cobranza B2B.{' '}
+              <span className="text-brand-primary">Visibilidad total de tu cartera.</span>
+            </h1>
+
+            <p className="text-slate-600 text-base md:text-xl leading-relaxed mb-8 max-w-2xl mx-auto">
+              Gestiona cuentas por cobrar, envía recordatorios automáticos y consolida tu cartera sin
+              reemplazar tu tech stack. Primer resultado en 30 días.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-3 justify-center mb-12">
+              <Button
+                text="Agenda demo gratuito"
+                variant="secondaryFilled"
+                size="lg"
+                onClick={scrollToForm}
+                rightIcon={<ArrowRight className="h-5 w-5" />}
+                className="w-full sm:w-auto min-h-[48px]"
+              />
+              <Button
+                text="Ver cómo funciona"
+                variant="primaryInvertedFilled"
+                size="lg"
+                onClick={() => {
+                  const el = document.getElementById('como-funciona')
+                  if (el) window.scrollTo({ top: el.getBoundingClientRect().top + window.pageYOffset - 72, behavior: 'smooth' })
+                }}
+                className="w-full sm:w-auto min-h-[48px] border border-slate-300"
+              />
+            </div>
+
+            {/* Stats bar */}
+            <div className="grid grid-cols-3 gap-4 bg-white rounded-2xl shadow-lg p-6 max-w-2xl mx-auto">
+              <div className="text-center">
+                <div className="text-2xl md:text-3xl font-extrabold text-brand-primary mb-1">30 días</div>
+                <div className="text-slate-500 text-xs md:text-sm font-medium leading-tight">
+                  Primer resultado
+                </div>
+              </div>
+              <div className="text-center border-x border-slate-200">
+                <div className="text-2xl md:text-3xl font-extrabold text-brand-primary mb-1">+85%</div>
+                <div className="text-slate-500 text-xs md:text-sm font-medium leading-tight">
+                  Tasa de recupero
+                </div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl md:text-3xl font-extrabold text-brand-primary mb-1">0</div>
+                <div className="text-slate-500 text-xs md:text-sm font-medium leading-tight">
+                  Cambios a tu stack
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Pain points — agitación */}
+        <section className="bg-white py-12 md:py-16">
+          <div className="max-w-[1280px] mx-auto px-4">
+            <h2 className="text-brand-primary-dark text-2xl md:text-3xl font-extrabold text-center mb-2">
+              ¿Te suena esto?
+            </h2>
+            <p className="text-slate-500 text-center mb-10">
+              El dinero está. Solo que no está disponible.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto">
+              {[
+                {
+                  icon: <BarChart2 className="h-6 w-6 text-brand-primary" />,
+                  title: 'Capital atrapado',
+                  desc: 'Tienes cartera vencida de más de 60 días y no sabes exactamente cuánto ni de quién.',
+                },
+                {
+                  icon: <Eye className="h-6 w-6 text-brand-primary" />,
+                  title: 'Cobranza a ciegas',
+                  desc: 'Tu equipo gestiona en Excel o Sheets. Nadie es el dueño del proceso y las cosas se pierden.',
+                },
+                {
+                  icon: <Zap className="h-6 w-6 text-brand-primary" />,
+                  title: 'Decisiones sin datos',
+                  desc: 'No puedes saber qué clientes van a pagar, cuáles necesitan acción urgente ni tu flujo real.',
+                },
+              ].map((item) => (
+                <div key={item.title} className="bg-slate-50 rounded-2xl p-6 border border-slate-100">
+                  <div className="h-10 w-10 bg-brand-primary/10 rounded-xl flex items-center justify-center mb-4">
+                    {item.icon}
+                  </div>
+                  <h3 className="font-bold text-brand-primary-dark text-base mb-2">{item.title}</h3>
+                  <p className="text-slate-500 text-sm leading-relaxed">{item.desc}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* How it works */}
+        <section id="como-funciona" className="py-12 md:py-16">
+          <div className="max-w-[1280px] mx-auto px-4">
+            <h2 className="text-brand-primary-dark text-2xl md:text-3xl font-extrabold text-center mb-10">
+              Cómo Sena resuelve cada dolor
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto">
+              {[
+                {
+                  step: '01',
+                  title: 'Visibilidad total',
+                  desc: 'Dashboard unificado de toda tu cartera. Sabes quién debe, cuánto y hace cuánto. En tiempo real.',
+                },
+                {
+                  step: '02',
+                  title: 'Cobranza automática',
+                  desc: 'Recordatorios por WhatsApp, email y llamada. El sistema aprende qué canal funciona con cada cliente.',
+                },
+                {
+                  step: '03',
+                  title: 'Conciliación sin fricción',
+                  desc: 'Se integra con tu ERP o facturador. Sin reemplazar nada. Funcional en días, no meses.',
+                },
+              ].map((item) => (
+                <div key={item.step} className="bg-white rounded-2xl p-6 shadow-sm border border-slate-100">
+                  <div className="text-4xl font-extrabold text-brand-primary/20 mb-3">{item.step}</div>
+                  <h3 className="font-bold text-brand-primary-dark text-base mb-2">{item.title}</h3>
+                  <p className="text-slate-500 text-sm leading-relaxed">{item.desc}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Trust signals */}
+        <section className="bg-white py-10 border-y border-slate-100">
+          <div className="max-w-[1280px] mx-auto px-4">
+            <p className="text-center text-sm text-slate-400 font-medium mb-6">
+              Respaldados por Recsa — 40 años de experiencia en cobranza en Chile y LATAM
+            </p>
+            <div className="flex flex-wrap justify-center gap-6 items-center">
+              {[
+                'Sin contrato de largo plazo',
+                'Implementación en días',
+                'Soporte en español',
+                'Datos 100% en Chile',
+              ].map((item) => (
+                <div key={item} className="flex items-center gap-2 text-slate-600 text-sm">
+                  <CheckCircle className="h-4 w-4 text-brand-primary shrink-0" />
+                  <span>{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Contact form section — placeholder; form se agrega en task #230 */}
+        <section id="contacto" className="py-12 md:py-20">
+          <div className="max-w-[1280px] mx-auto px-4">
+            <div className="max-w-lg mx-auto text-center">
+              <h2 className="text-brand-primary-dark text-2xl md:text-4xl font-extrabold mb-3">
+                Agenda tu demo de{' '}
+                <span className="text-brand-primary">30 minutos</span>
+              </h2>
+              <p className="text-slate-500 mb-8">
+                Sin compromiso. Te mostramos cómo funciona con tu cartera real.
+              </p>
+              {/* Form: task #230 */}
+              <div className="bg-white rounded-2xl shadow-sm border border-slate-100 p-8">
+                <p className="text-slate-400 text-sm">Formulario de contacto — próxima task</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      {/* Footer minimal */}
+      <footer className="bg-white border-t border-slate-100 py-6 px-4">
+        <div className="max-w-[1280px] mx-auto flex flex-col md:flex-row items-center justify-between gap-3 text-xs text-slate-400">
+          <Link href="/">
+            <Image src={AssetImage.logoBlack} alt="Sena" className="h-5 w-auto opacity-60" />
+          </Link>
+          <div className="flex gap-4">
+            <Link href="/term" className="hover:text-slate-600 transition-colors">
+              Términos
+            </Link>
+            <Link href="/privacy" className="hover:text-slate-600 transition-colors">
+              Privacidad
+            </Link>
+            <Link href="/" className="hover:text-slate-600 transition-colors">
+              somossena.com
+            </Link>
+          </div>
+        </div>
+      </footer>
+
+      <StickyMobileCTA />
+    </div>
+  )
+}

--- a/src/ui/plataforma/sections/PlataformaContactForm.tsx
+++ b/src/ui/plataforma/sections/PlataformaContactForm.tsx
@@ -1,0 +1,289 @@
+'use client'
+
+import { useCountries } from '@/lib/services/countryService'
+import { useCurrencyStore } from '@/lib/store/useCurrencyStore'
+import Button from '@/ui/shared/Button'
+import { Input } from '@/ui/shared/Input'
+import SimpleCountrySelect, { OptionSelect } from '@/ui/shared/SimpleCountrySelect'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useMemo, useState } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+    fbq?: (...args: unknown[]) => void
+  }
+}
+
+type FormData = {
+  nombre: string
+  apellido: string
+  empresa: string
+  email: string
+  whatsapp: string
+  facturas_pendientes: string
+  alguien_cobrando: string
+}
+
+export const PlataformaContactForm = () => {
+  const [isLoading, setIsLoading] = useState(false)
+  const { data: countries = [] } = useCountries()
+  const { ipCurrency } = useCurrencyStore()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [countrySelect, setCountrySelect] = useState<string | null>(null)
+  const [gclid, setGclid] = useState<string | null>(null)
+  const [fbclid, setFbclid] = useState<string | null>(null)
+
+  const utmSource = searchParams?.get('utm_source') || null
+  const utmMedium = searchParams?.get('utm_medium') || null
+  const utmCampaign = searchParams?.get('utm_campaign') || null
+  const utmContent = searchParams?.get('utm_content') || null
+  const utmTerm = searchParams?.get('utm_term') || null
+
+  const countryOptions = useMemo(() => {
+    if (!countries.length) return []
+    const priority = ['+51', '+56', '+57', '+593', '+52']
+    const priorityItems: OptionSelect[] = []
+    const otherItems: OptionSelect[] = []
+    countries.forEach((item) => {
+      const option: OptionSelect = { id: item.country, label: item.country, icon: item.icon, subValue: item.country }
+      if (priority.includes(item.country)) priorityItems.push(option)
+      else otherItems.push(option)
+    })
+    priorityItems.sort((a, b) => priority.indexOf(a.id) - priority.indexOf(b.id))
+    return [...priorityItems, ...otherItems]
+  }, [countries])
+
+  useEffect(() => {
+    const currencyMap: Record<string, string> = { PEN: '+51', CLP: '+56', COP: '+57', MXN: '+52', USD: '+593' }
+    if (ipCurrency && currencyMap[ipCurrency]) setCountrySelect(currencyMap[ipCurrency])
+  }, [ipCurrency])
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const gc = params.get('gclid') || sessionStorage.getItem('gclid')
+    const fb = params.get('fbclid') || sessionStorage.getItem('fbclid')
+    if (gc) { setGclid(gc); sessionStorage.setItem('gclid', gc) }
+    if (fb) { setFbclid(fb); sessionStorage.setItem('fbclid', fb) }
+  }, [])
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    defaultValues: {
+      nombre: '', apellido: '', empresa: '', email: '', whatsapp: '',
+      facturas_pendientes: '', alguien_cobrando: '',
+    },
+  })
+
+  const onSubmit = async (data: FormData) => {
+    setIsLoading(true)
+    const telefono = (countrySelect || '') + data.whatsapp
+    try {
+      await fetch('/api/lead', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          nombre: data.nombre,
+          apellido: data.apellido,
+          empresa: data.empresa,
+          email: data.email,
+          telefono,
+          facturas_pendientes: data.facturas_pendientes,
+          alguien_cobrando: data.alguien_cobrando,
+          utmSource: utmSource ?? undefined,
+          utmMedium: utmMedium ?? undefined,
+          utmCampaign: utmCampaign ?? undefined,
+          utmContent: utmContent ?? undefined,
+          utmTerm: utmTerm ?? undefined,
+          gclid: gclid ?? undefined,
+          fbclid: fbclid ?? undefined,
+          landingPage: window.location.href,
+        }),
+      }).catch(() => {})
+
+      if (window.gtag) {
+        window.gtag('event', 'completar_formulario', { product: 'plataforma' })
+        window.gtag('event', 'conversion', { send_to: 'AW-17962976949/JNP9CMq42ZgcELWNtfVC' })
+      }
+      if (window.fbq) window.fbq('track', 'Lead', { content_name: 'plataforma' })
+
+      router.push('/plataforma/gracias')
+    } catch {
+      setIsLoading(false)
+    }
+  }
+
+  const facturaOpciones = [
+    { value: '1-10', label: '1-10' },
+    { value: '10-50', label: '10-50' },
+    { value: '50+', label: '50+' },
+  ]
+
+  const cobranzaOpciones = [
+    { value: 'Sí', label: 'Sí' },
+    { value: 'No', label: 'No' },
+    { value: 'A veces', label: 'A veces' },
+  ]
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="w-full rounded-2xl bg-white shadow-sm border border-slate-100 p-6 md:p-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        <Controller
+          name="nombre"
+          control={control}
+          rules={{ required: 'El nombre es obligatorio' }}
+          render={({ field }) => (
+            <Input label="Nombre" placeholder="Tu nombre" {...field} error={errors.nombre?.message} />
+          )}
+        />
+        <Controller
+          name="apellido"
+          control={control}
+          rules={{ required: 'El apellido es obligatorio' }}
+          render={({ field }) => (
+            <Input label="Apellido" placeholder="Tu apellido" {...field} error={errors.apellido?.message} />
+          )}
+        />
+      </div>
+
+      <div className="mb-4">
+        <Controller
+          name="empresa"
+          control={control}
+          rules={{ required: 'El nombre de la empresa es obligatorio' }}
+          render={({ field }) => (
+            <Input label="Empresa" placeholder="Nombre de tu empresa" {...field} error={errors.empresa?.message} />
+          )}
+        />
+      </div>
+
+      <div className="mb-4">
+        <Controller
+          name="email"
+          control={control}
+          rules={{
+            required: 'El email es obligatorio',
+            pattern: { value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i, message: 'Email inválido' },
+          }}
+          render={({ field }) => (
+            <Input label="Email" type="email" placeholder="tu@empresa.com" {...field} error={errors.email?.message} />
+          )}
+        />
+      </div>
+
+      <div className="mb-4">
+        <Controller
+          name="whatsapp"
+          control={control}
+          rules={{
+            required: 'El número de WhatsApp es obligatorio',
+            pattern: { value: /^[0-9]+$/, message: 'Solo se permiten números' },
+          }}
+          render={({ field }) => (
+            <Input
+              label="WhatsApp"
+              type="tel"
+              placeholder="Número"
+              value={field.value || ''}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => field.onChange(e.target.value.replace(/\D/g, ''))}
+              error={errors.whatsapp?.message}
+              leftElement={
+                <SimpleCountrySelect
+                  value={countrySelect}
+                  onChange={(value: string) => setCountrySelect(value)}
+                  options={countryOptions}
+                />
+              }
+            />
+          )}
+        />
+      </div>
+
+      <div className="mb-5">
+        <label className="block text-sm font-bold text-black mb-3">
+          ¿Cuántas facturas tienes pendientes?<span className="text-red-500">*</span>
+        </label>
+        <Controller
+          name="facturas_pendientes"
+          control={control}
+          rules={{ required: 'Debes seleccionar una opción' }}
+          render={({ field }) => (
+            <div className="flex flex-wrap gap-2">
+              {facturaOpciones.map((op) => (
+                <button
+                  key={op.value}
+                  type="button"
+                  onClick={() => field.onChange(op.value)}
+                  className={`min-h-[44px] px-5 py-2 rounded-full border-2 text-sm font-semibold transition-colors ${
+                    field.value === op.value
+                      ? 'border-brand-primary bg-brand-primary text-white'
+                      : 'border-slate-200 bg-white text-slate-700 hover:border-brand-primary'
+                  }`}
+                >
+                  {op.label}
+                </button>
+              ))}
+            </div>
+          )}
+        />
+        {errors.facturas_pendientes && (
+          <p className="text-red-500 text-xs mt-1">{errors.facturas_pendientes.message}</p>
+        )}
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-sm font-bold text-black mb-3">
+          ¿Alguien en tu equipo se encarga de cobrar?<span className="text-red-500">*</span>
+        </label>
+        <Controller
+          name="alguien_cobrando"
+          control={control}
+          rules={{ required: 'Debes seleccionar una opción' }}
+          render={({ field }) => (
+            <div className="flex flex-wrap gap-2">
+              {cobranzaOpciones.map((op) => (
+                <button
+                  key={op.value}
+                  type="button"
+                  onClick={() => field.onChange(op.value)}
+                  className={`min-h-[44px] px-5 py-2 rounded-full border-2 text-sm font-semibold transition-colors ${
+                    field.value === op.value
+                      ? 'border-brand-primary bg-brand-primary text-white'
+                      : 'border-slate-200 bg-white text-slate-700 hover:border-brand-primary'
+                  }`}
+                >
+                  {op.label}
+                </button>
+              ))}
+            </div>
+          )}
+        />
+        {errors.alguien_cobrando && (
+          <p className="text-red-500 text-xs mt-1">{errors.alguien_cobrando.message}</p>
+        )}
+      </div>
+
+      <p className="text-xs text-slate-500 mb-5">
+        Al enviar, aceptas los{' '}
+        <Link href="/term" className="text-brand-primary font-semibold hover:underline">Términos</Link>{' '}
+        y la{' '}
+        <Link href="/privacy" className="text-brand-primary font-semibold hover:underline">Política de Privacidad</Link>.
+      </p>
+
+      <Button
+        type="submit"
+        text={isLoading ? 'Enviando...' : 'Solicitar demo gratuito'}
+        variant="secondaryFilled"
+        size="md"
+        className="w-full md:w-auto min-h-[44px]"
+        disabled={isLoading}
+      />
+    </form>
+  )
+}


### PR DESCRIPTION
## Qué incluye

**feature #225 — /plataforma landing foco Google Ads**
- Landing `/plataforma` sin nav principal — H1 message-match para ads
- Formulario inline con gclid/UTM capture, pill buttons, POST `/api/lead` → HubSpot
- `/plataforma/gracias` con embed HubSpot meetings (francisco502) + GA4 `completar_formulario`
- Sticky CTA mobile

**Fixes**
- Footer: `© SENA SE 2026` → `© Sena 2026`
- Blog: post destacado actualizado al más reciente (17 abril 2026)

## Variables de entorno requeridas en Vercel (producción)

Ninguna nueva — el webhook N8N fue removido, HubSpot ya notifica.

## Test plan

- [ ] `/plataforma` carga con formulario visible above fold
- [ ] Submit → contacto aparece en HubSpot con gclid/UTM
- [ ] `/plataforma/gracias` muestra calendario HubSpot
- [ ] Footer muestra `© Sena 2026`
- [ ] Blog muestra post de abril 2026 como destacado

🤖 Generated with [Claude Code](https://claude.com/claude-code)